### PR TITLE
Add support for folded strings

### DIFF
--- a/src/main/scala-2/unindent/UnindentMacros.scala
+++ b/src/main/scala-2/unindent/UnindentMacros.scala
@@ -7,10 +7,21 @@ class UnindentMacros(val c: Context) {
   import c.universe._
 
   private val prefixRegex = """^\n""".r
+  private val singlePrefixRegex = """^\n(?!\n)""".r
   private val suffixRegex = """\n[ \t]*$""".r
+  private val singleSuffixRegex = """(?<!\n)\n(?!\n)[ \t]*$""".r
   private val indentRegex = """\n[ \t]+""".r
+  private val newlinesRegex = """\n+""".r
 
-  def unindentMacro(args: c.Tree*): c.Tree = {
+  def unindentMacroUnfolded(args: c.Tree*): c.Tree = {
+    unindentMacro(false, args: _*)
+  }
+
+  def unindentMacroFolded(args: c.Tree*): c.Tree = {
+    unindentMacro(true, args: _*)
+  }
+
+  def unindentMacro(folded: Boolean, args: c.Tree*): c.Tree = {
     val indentedStrings: Seq[String] =
       c.prefix.tree match {
         case Apply(_, List(Apply(_, partTrees))) =>
@@ -46,6 +57,32 @@ class UnindentMacros(val c: Context) {
         ans
       }
 
-    q"_root_.scala.StringContext(..$unindentedStrings).s(..$args)"
+    val foldedUnindentedStrings: Seq[String] =
+      indentedStrings.zipWithIndex.map { case (part, index) =>
+        // De-indent newlines:
+        var ans = indentRegex
+          .replaceAllIn(part, (m: Regex.Match) => "\n" + (" " * (m.group(0).length - minIndent)))
+
+        // Strip any single initial newline from the beginning of the string:
+        if (index == 0) {
+          ans = singlePrefixRegex.replaceFirstIn(ans, "")
+        }
+
+        // Strip any single final newline from the end of the string:
+        if (index == numIndentedStrings - 1) {
+          ans = singleSuffixRegex.replaceFirstIn(ans, "")
+        }
+
+        // Remove non-consecutive newlines:
+        ans = newlinesRegex.replaceAllIn(ans, (m: Regex.Match) =>
+          if (m.group(0).length == 1) " " else "\n" * (m.group(0).length - 1))
+
+        ans
+      }
+
+    if (folded)
+      q"_root_.scala.StringContext(..$foldedUnindentedStrings).s(..$args)"
+    else
+      q"_root_.scala.StringContext(..$unindentedStrings).s(..$args)"
   }
 }

--- a/src/main/scala-2/unindent/package.scala
+++ b/src/main/scala-2/unindent/package.scala
@@ -3,6 +3,6 @@ import scala.language.experimental.macros
 package object unindent {
   implicit class UnindentSyntax(val ctx: StringContext) extends AnyVal {
     def i(args: Any*): String = macro UnindentMacros.unindentMacroUnfolded
-    def y(args: Any*): String = macro UnindentMacros.unindentMacroFolded
+    def i1(args: Any*): String = macro UnindentMacros.unindentMacroFolded
   }
 }

--- a/src/main/scala-2/unindent/package.scala
+++ b/src/main/scala-2/unindent/package.scala
@@ -2,6 +2,7 @@ import scala.language.experimental.macros
 
 package object unindent {
   implicit class UnindentSyntax(val ctx: StringContext) extends AnyVal {
-    def i(args: Any*): String = macro UnindentMacros.unindentMacro
+    def i(args: Any*): String = macro UnindentMacros.unindentMacroUnfolded
+    def y(args: Any*): String = macro UnindentMacros.unindentMacroFolded
   }
 }

--- a/src/main/scala-3/unindent/UnindentMacros.scala
+++ b/src/main/scala-3/unindent/UnindentMacros.scala
@@ -5,10 +5,16 @@ import scala.util.matching.Regex
 
 object UnindentMacros:
   private val prefixRegex = """^\n""".r
+  private val singlePrefixRegex = """^\n(?!\n)""".r
   private val suffixRegex = """\n[ \t]*$""".r
+  private val singleSuffixRegex = """(?<!\n)\n(?!\n)[ \t]*$""".r
   private val indentRegex = """\n[ \t]+""".r
+  private val newlinesRegex = """\n+""".r
 
-  def unindentMacro(ctx: Expr[StringContext], args: Expr[Seq[Any]])(using Quotes): Expr[String] =
+  def unindentMacro(ctx: Expr[StringContext],
+                    args: Expr[Seq[Any]],
+                    folded: Boolean)
+                    (using Quotes): Expr[String] =
     val indentedStrings: Seq[String] =
       ctx match
         case '{ StringContext(${Varargs(indentedStrings)} *) } =>
@@ -41,7 +47,31 @@ object UnindentMacros:
         ans
       }
 
+    val foldedUnindentedStrings: Seq[String] =
+      indentedStrings.zipWithIndex.map { case (part, index) =>
+        // De-indent newlines:
+        var ans = indentRegex
+          .replaceAllIn(part, (m: Regex.Match) => "\n" + (" " * (m.group(0).length - minIndent)))
+
+        // Strip any single initial newline from the beginning of the string:
+        if index == 0 then
+          ans = singlePrefixRegex.replaceFirstIn(ans, "")
+
+        // Strip any single final newline from the end of the string:
+        if index == numIndentedStrings - 1 then
+          ans = singleSuffixRegex.replaceFirstIn(ans, "")
+
+        // Remove non-consecutive newlines:
+        ans = newlinesRegex.replaceAllIn(ans, (m: Regex.Match) =>
+          if m.group(0).length == 1 then " " else "\n" * (m.group(0).length - 1))
+
+        ans
+      }
+
     val unindentedExprs: Seq[Expr[String]] =
-      unindentedStrings.map(Expr(_))
+      if folded then
+        foldedUnindentedStrings.map(Expr(_))
+      else
+        unindentedStrings.map(Expr(_))
 
     '{ StringContext(${Varargs(unindentedExprs)} *).s($args *) }

--- a/src/main/scala-3/unindent/package.scala
+++ b/src/main/scala-3/unindent/package.scala
@@ -5,5 +5,5 @@ import scala.quoted.*
 extension (inline ctx: StringContext)
   inline def i(inline args: Any *): String =
     ${ UnindentMacros.unindentMacro('ctx, 'args, false) }
-  inline def y(inline args: Any *): String =
+  inline def i1(inline args: Any *): String =
     ${ UnindentMacros.unindentMacro('ctx, 'args, true) }

--- a/src/main/scala-3/unindent/package.scala
+++ b/src/main/scala-3/unindent/package.scala
@@ -4,4 +4,6 @@ import scala.quoted.*
 
 extension (inline ctx: StringContext)
   inline def i(inline args: Any *): String =
-    ${ UnindentMacros.unindentMacro('ctx, 'args) }
+    ${ UnindentMacros.unindentMacro('ctx, 'args, false) }
+  inline def y(inline args: Any *): String =
+    ${ UnindentMacros.unindentMacro('ctx, 'args, true) }

--- a/src/test/scala/unindent/UnindentSpec.scala
+++ b/src/test/scala/unindent/UnindentSpec.scala
@@ -81,3 +81,90 @@ class UnindentSpec extends munit.FunSuite {
     assert(i"${1 + 1}" == s"2")
   }
 }
+
+class FoldedUnindentSpec extends munit.FunSuite {
+  test("folded unindent automatically") {
+    val actual =
+      y"""This is a multi-line string.
+      This line is concated to the previous.
+
+      This line begins with a newline.
+        This line is prefixed by three spaces."""
+
+    val expected =
+      s"""This is a multi-line string. This line is concated to the previous.
+      |This line begins with a newline.   This line is prefixed by three spaces.
+      """.trim.stripMargin
+
+    assert(actual == expected)
+  }
+
+  test("strip initial and final line breaks") {
+    val actual =
+      y"""
+      This is an indented multi-line string.
+
+      This line ends up unindented.
+
+        This line ends up indented by two spaces.
+      """
+
+    val expected =
+      s"""This is an indented multi-line string.
+      |This line ends up unindented.
+      |  This line ends up indented by two spaces.
+      """.trim.stripMargin
+
+    assert(actual == expected)
+  }
+
+  test("don't strip off double initial and final line breaks") {
+    val actual =
+      y"""
+
+      This is an indented multi-line string.
+
+      This line ends up unindented.
+
+        This line ends up indented by two spaces.
+
+      """
+
+    val expected =
+      s"""
+      |
+      |This is an indented multi-line string.
+      |This line ends up unindented.
+      |  This line ends up indented by two spaces.
+      |
+      """.trim.stripMargin
+
+    assert(actual == expected)
+  }
+
+  test("allow interpolation") {
+    val actual =
+      y"""
+      This is an intepolated bit ${1 + 1}
+        ${2 + 2} that's one too
+
+      This one is in the ${3 + 3} middle of a line
+      """
+
+    val expected =
+      s"""
+      |This is an intepolated bit 2   4 that's one too
+      |This one is in the 6 middle of a line
+      """.trim.stripMargin
+
+    assert(actual == expected)
+  }
+
+  test("corner case - empty string") {
+    assert(y"" == s"")
+  }
+
+  test("corner case - solitary interpolation") {
+    assert(y"${1 + 1}" == s"2")
+  }
+}

--- a/src/test/scala/unindent/UnindentSpec.scala
+++ b/src/test/scala/unindent/UnindentSpec.scala
@@ -85,7 +85,7 @@ class UnindentSpec extends munit.FunSuite {
 class FoldedUnindentSpec extends munit.FunSuite {
   test("folded unindent automatically") {
     val actual =
-      y"""This is a multi-line string.
+      i1"""This is a multi-line string.
       This line is concated to the previous.
 
       This line begins with a newline.
@@ -101,7 +101,7 @@ class FoldedUnindentSpec extends munit.FunSuite {
 
   test("strip initial and final line breaks") {
     val actual =
-      y"""
+      i1"""
       This is an indented multi-line string.
 
       This line ends up unindented.
@@ -120,7 +120,7 @@ class FoldedUnindentSpec extends munit.FunSuite {
 
   test("don't strip off double initial and final line breaks") {
     val actual =
-      y"""
+      i1"""
 
       This is an indented multi-line string.
 
@@ -144,7 +144,7 @@ class FoldedUnindentSpec extends munit.FunSuite {
 
   test("allow interpolation") {
     val actual =
-      y"""
+      i1"""
       This is an intepolated bit ${1 + 1}
         ${2 + 2} that's one too
 
@@ -161,10 +161,10 @@ class FoldedUnindentSpec extends munit.FunSuite {
   }
 
   test("corner case - empty string") {
-    assert(y"" == s"")
+    assert(i1"" == s"")
   }
 
   test("corner case - solitary interpolation") {
-    assert(y"${1 + 1}" == s"2")
+    assert(i1"${1 + 1}" == s"2")
   }
 }


### PR DESCRIPTION
Handy library! And thanks for adding support for Scala 3.

This PR adds support for strings in which non-consecutive newlines are resolved to spaces. This allows the writing of long strings without line breaks and prevents overflowing a reasonable column limit or needing string concatenation constantly. Line breaks are available by escaping through two or more consecutive newlines (one is removed). This is similar to the behavior of folded style yml strings following the '>' indicator.